### PR TITLE
Fix embedded snippet run by including language

### DIFF
--- a/frontend/src/pages/embed/index.tsx
+++ b/frontend/src/pages/embed/index.tsx
@@ -53,8 +53,10 @@ function EmbeddedPage() {
           name: response.name,
           ownerUsername: snippetParams.username,
           slug: response.slug,
+          language: response.language,
         }),
       );
+      dispatch(actions.changeLanguage(response.language));
       dispatch(actions.setCodeAndSavedCode(response.code));
     };
 


### PR DESCRIPTION
## Summary
- include the snippet language when populating embedded snippets
- ensure the editor language is updated when loading embedded snippets so the run button has the necessary data

## Testing
- `yarn test --watchAll=false` *(fails: Usage Error because frontend isn't part of the root yarn project workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d463122ff08333b323fa4306fc592e