### PR TITLE
Guard run button until snippet ready

### DIFF
--- a/frontend/src/hooks/useRunButton.js
+++ b/frontend/src/hooks/useRunButton.js
@@ -13,11 +13,20 @@ const useRunButton = () => {
     (state) => state.terminal.codeExecutionState,
   );
   const snippet = useSelector((state) => state.editor.snippetData);
-  const code = useSelector((state) => state.editor.code);
-  const onClick = useCallback(
-    () => dispatch(runCode({ ...snippet, code })),
-    [dispatch, code, snippet],
+  const isSnippetRunnable = Boolean(
+    snippet &&
+      snippet.id !== null &&
+      snippet.slug &&
+      snippet.language,
   );
+  const code = useSelector((state) => state.editor.code);
+  const onClick = useCallback(() => {
+    if (!isSnippetRunnable) {
+      return;
+    }
+
+    dispatch(runCode({ ...snippet, code }));
+  }, [dispatch, code, snippet, isSnippetRunnable]);
   const update = async (id, name) => {
     const response = await axios.put(routes.updateSnippetPath(id), {
       code,
@@ -27,7 +36,8 @@ const useRunButton = () => {
     return response;
   };
 
-  const disabled = codeExecutionState === 'executing';
+  const disabled =
+    codeExecutionState === 'executing' || !isSnippetRunnable;
 
   return {
     onClick,

--- a/frontend/src/pages/embed/index.tsx
+++ b/frontend/src/pages/embed/index.tsx
@@ -53,8 +53,10 @@ function EmbeddedPage() {
           name: response.name,
           ownerUsername: snippetParams.username,
           slug: response.slug,
+          language: response.language,
         }),
       );
+      dispatch(actions.changeLanguage(response.language));
       dispatch(actions.setCodeAndSavedCode(response.code));
     };
 


### PR DESCRIPTION
## Summary
- prevent run button from dispatching until snippet metadata is loaded so embeds wait for language information

## Testing
- `cd frontend && CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68d463122ff08333b323fa4306fc592e