### PR TITLE
Wait for auth resolution before rendering routes and add isAuthResolved to auth context; update frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,13 +1,29 @@
+### Требования
+
+- Node.js 24 LTS
+- Yarn 1 (Classic)
+
 ### Установка зависимостей
 
 ```bash
 cd frontend && make install
 ```
 
-или`make install`из **_~_/frontend**
+или `make install` из `~/frontend`.
 
-### Запуск приложения (front)
+### Локальный запуск
+
+1. Поднять backend из корня репозитория (порт `3001`):
 
 ```bash
-cd frontend && make start
+yarn
+yarn dev
+```
+
+2. Поднять frontend (порт `3000`):
+
+```bash
+cd frontend
+make install
+make start
 ```

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -49,7 +49,7 @@ function ProtectedRoute({ redirectTo = routes.homePagePath(), isAllowed }) {
 }
 
 function AppRoutes() {
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isAuthResolved } = useAuth();
   const { isDarkMode } = useTernaryDarkMode();
 
   useEffect(() => {
@@ -58,6 +58,10 @@ function AppRoutes() {
       isDarkMode ? 'dark' : 'light',
     );
   }, [isDarkMode]);
+
+  if (!isAuthResolved) {
+    return <DefaultLoader />;
+  }
 
   return (
     <Suspense fallback={<DefaultLoader />}>
@@ -78,9 +82,7 @@ function AppRoutes() {
         <Route
           element={
             <ProtectedRoute
-              // FIXME: Всегда isAllowed пока не готова авторизация
-              // isAllowed={!isLoggedIn}
-              isAllowed
+              isAllowed={!isLoggedIn}
               redirectTo={routes.myProfilePagePath()}
             />
           }

--- a/frontend/src/contexts/index.ts
+++ b/frontend/src/contexts/index.ts
@@ -5,6 +5,7 @@ export const AuthContext = createContext({
   signIn: () => null,
   signOut: () => null,
   isLoggedIn: false,
+  isAuthResolved: false,
 });
 
 export const SnippetsContext = createContext<ICreateSnippetsContext>({

--- a/frontend/src/providers/AuthProvider.jsx
+++ b/frontend/src/providers/AuthProvider.jsx
@@ -13,6 +13,7 @@ function AuthProvider({ children }) {
   const [isLoggedIn, setLoggedIn] = useState(
     signInStatus ? signInStatus.status : false,
   );
+  const [isAuthResolved, setAuthResolved] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -25,6 +26,9 @@ function AuthProvider({ children }) {
         localStorage.removeItem('signInStatus');
         localStorage.removeItem('guestUserData');
         setLoggedIn(false);
+      })
+      .finally(() => {
+        setAuthResolved(true);
       });
   }, [dispatch]);
 
@@ -39,9 +43,14 @@ function AuthProvider({ children }) {
 
       signIn: () => {
         localStorage.removeItem('guestUserData');
+        setAuthResolved(false);
         dispatch(fetchUserData())
           .unwrap()
+          .then(() => {
+            setAuthResolved(true);
+          })
           .catch((serializedError) => {
+            setAuthResolved(true);
             const error = new Error(serializedError.message);
             error.name = serializedError.name;
             throw error;
@@ -50,8 +59,9 @@ function AuthProvider({ children }) {
         setLoggedIn(true);
       },
       isLoggedIn,
+      isAuthResolved,
     }),
-    [dispatch, isLoggedIn, navigate],
+    [dispatch, isAuthResolved, isLoggedIn, navigate],
   );
 
   return (


### PR DESCRIPTION
### Motivation

- Ensure the app does not render routes until the authentication state is fully resolved to prevent flashes or incorrect redirects.  
- Propagate an auth resolution flag through the auth context to allow consumers to wait for auth checks.  
- Adjust route protection logic so the landing page is only available to unauthenticated users.  
- Make local frontend setup instructions clearer in `frontend/README.md`.

### Description

- Added `isAuthResolved` to `AuthContext` and to the `AuthProvider` state to track when initial auth check completes.  
- Updated `AuthProvider` to set `isAuthResolved` on the initial `fetchUserData()` flow and during `signIn` handling, and added it to the `useMemo` value and deps.  
- Updated `AppRoutes` to read `isAuthResolved` from `useAuth()` and render `DefaultLoader` until auth resolution is complete.  
- Restored landing route protection to only allow unauthenticated users by changing the protected check to `isAllowed={!isLoggedIn}` and kept other `ProtectedRoute` checks intact.  
- Clarified `frontend/README.md` with Node/Yarn requirements and step-by-step local startup commands for backend and frontend.

### Testing

- Ran the frontend build via `yarn build` in the `frontend` workspace and it completed successfully.  
- Ran the frontend test suite with `yarn test` and all tests passed.  
- Verified the app starts locally with `make install` and `make start` in `frontend` during manual smoke runs (non-automated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c72105288333ae3b2015b8e4dc2f)