### PR TITLE
Add paginated/filtered snippet listing and fix deleteUser response

### DIFF
--- a/src/db/snippets.ts
+++ b/src/db/snippets.ts
@@ -40,8 +40,16 @@ export const getSnippetByUsernameSlugSchema = z.object({
   slug: z.string()
 });
 
+export const listSnippetsSchema = z.object({
+  limit: z.number().int().positive().max(100).default(20),
+  offset: z.number().int().nonnegative().default(0),
+  language: z.enum(['ruby', 'java', 'php', 'python', 'javascript', 'html']).optional(),
+  userId: z.number().int().positive().optional(),
+});
+
 export type CreateSnippetInput = z.infer<typeof createSnippetSchema>;
 export type UpdateSnippetInput = z.infer<typeof updateSnippetSchema>;
+export type ListSnippetsInput = z.infer<typeof listSnippetsSchema>;
 
 async function verifyUserExists(userId: number): Promise<void> {
   const [user] = await db
@@ -113,6 +121,37 @@ export async function getAllSnippets(): Promise<Snippet[]> {
   } catch (error) {
     console.error('Error in getAllSnippets:', error);
     throw new Error('Failed to get all snippets');
+  }
+}
+
+export async function listSnippets(params: ListSnippetsInput): Promise<Snippet[]> {
+  const { limit, offset, language, userId } = params;
+
+  try {
+    const whereClause = [
+      language ? eq(snippets.language, language) : undefined,
+      userId ? eq(snippets.userId, userId) : undefined,
+    ].filter((value): value is NonNullable<typeof value> => value !== undefined);
+
+    if (whereClause.length === 0) {
+      return await db
+        .select()
+        .from(snippets)
+        .orderBy(desc(snippets.createdAt))
+        .limit(limit)
+        .offset(offset);
+    }
+
+    return await db
+      .select()
+      .from(snippets)
+      .where(and(...whereClause))
+      .orderBy(desc(snippets.createdAt))
+      .limit(limit)
+      .offset(offset);
+  } catch (error) {
+    console.error('Error in listSnippets:', error);
+    throw new Error('Failed to list snippets');
   }
 }
 

--- a/src/router/snippetRouter.ts
+++ b/src/router/snippetRouter.ts
@@ -8,6 +8,8 @@ import {
   getSnippetById,
   getSnippetByUsernameSlug,
   getAllSnippets,
+  listSnippetsSchema,
+  listSnippets,
   createSnippet,
   updateSnippet,
   deleteSnippet,
@@ -41,6 +43,13 @@ export const snippetRouter = router({
     .query(async () => {
       console.log('getAllSnippets called');
       return await getAllSnippets();
+    }),
+
+
+  listSnippets: publicProcedure
+    .input(listSnippetsSchema)
+    .query(async ({ input }) => {
+      return await listSnippets(input);
     }),
 
   createSnippet: publicProcedure

--- a/src/router/userRouter.ts
+++ b/src/router/userRouter.ts
@@ -79,7 +79,7 @@ export const userRouter = router({
         throw new Error('User not found');
       }
       
-      return { success: true, id: input };
+      return { success: true, id: input.id };
     }),
 
 


### PR DESCRIPTION
### Motivation
- Provide a scalable snippet listing API with pagination and optional filters to avoid returning the full dataset.
- Surface a small bugfix to ensure `deleteUser` returns a numeric `id` instead of the whole input object.

### Description
- Added `listSnippetsSchema` and `ListSnippetsInput` in `src/db/snippets.ts` to validate pagination and filter parameters (`limit`, `offset`, `language`, `userId`).
- Implemented `listSnippets(params: ListSnippetsInput)` in `src/db/snippets.ts` which supports optional `language` and `userId` filters plus `limit`/`offset`, and orders by `createdAt` descending.
- Exposed a new tRPC endpoint `snippets.listSnippets` in `src/router/snippetRouter.ts` wired to the new schema and function.
- Fixed `deleteUser` response in `src/router/userRouter.ts` to return `{ success: true, id: input.id }` (previously returned the whole `input` object).

### Testing
- Ran TypeScript type check with `npx tsc --noEmit`, which completed successfully.
- Built the project with `npm run build` (which runs DB generation/migrations and `tsc`), and the build completed successfully with migrations applied.
- Verified no type errors after changes and that the new endpoint compiles into the server code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d55a77ac83338dcb2e9f698ba0d5)