### PR TITLE
Fix ESM startup (use .js specifiers) and clean Playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-require('dotenv').config();
-
-/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import * as schema from './schema/schema';
+import * as schema from './schema/schema.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/src/db/snippets.ts
+++ b/src/db/snippets.ts
@@ -1,9 +1,9 @@
 import { eq, and, desc } from 'drizzle-orm';
 import { z } from 'zod/v3';
-import { db } from './connection';
-import { snippets, users, type Snippet, type NewSnippet } from './schema/schema';
+import { db } from './connection.js';
+import { snippets, users, type Snippet, type NewSnippet } from './schema/schema.js';
 import { faker } from '@faker-js/faker';
-import { generateUniqSlug } from '../utils/generate-uniq-slug';
+import { generateUniqSlug } from '../utils/generate-uniq-slug.js';
 
 export const snippetSchema = z.object({
   id: z.number(),

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,6 +1,6 @@
 import { eq, desc } from 'drizzle-orm';
 import { z } from 'zod/v3';
-import { db } from './connection';
+import { db } from './connection.js';
 import { 
   users,
   snippets, 
@@ -9,7 +9,7 @@ import {
   type NewUser,
   type UserSettings,
   type NewUserSettings
- } from './schema/schema';
+ } from './schema/schema.js';
 
  // to do:
  // 1) дописать сброс пароля resetPassword

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { fastify } from 'fastify';
 import { fastifyTRPCPlugin, FastifyTRPCPluginOptions, } from '@trpc/server/adapters/fastify';
 
-import { runMigrations } from './db/connection';
-import { appRouter, type AppRouter } from './router/index';
+import { runMigrations } from './db/connection.js';
+import { appRouter, type AppRouter } from './router/index.js';
 // import { createContext } from './context';
 
 const getApp = async () => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
-import { router } from '../context';
-import { userRouter } from './userRouter';
-import { snippetRouter } from './snippetRouter';
+import { router } from '../context.js';
+import { userRouter } from './userRouter.js';
+import { snippetRouter } from './snippetRouter.js';
 
 export const appRouter = router({
   users: userRouter,    // Роутер для пользователей

--- a/src/router/snippetRouter.ts
+++ b/src/router/snippetRouter.ts
@@ -1,4 +1,4 @@
-import { router, publicProcedure } from '../context';
+import { router, publicProcedure } from '../context.js';
 import { 
   createSnippetSchema, 
   updateSnippetSchema,
@@ -14,7 +14,7 @@ import {
   updateSnippet,
   deleteSnippet,
   generateName
-} from '../db/snippets';
+} from '../db/snippets.js';
 
 export const snippetRouter = router({
 

--- a/src/router/userRouter.ts
+++ b/src/router/userRouter.ts
@@ -1,4 +1,4 @@
-import { router, publicProcedure } from '../context';
+import { router, publicProcedure } from '../context.js';
 
 import {
   getUserById,
@@ -19,7 +19,7 @@ import {
   deleteUserSchema,
   updateUserSchema,
   updateUserSettingsSchema,
-} from '../db/users';
+} from '../db/users.js';
 
 export const userRouter = router({
   getUserById: publicProcedure

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,9 @@
-import getApp from './index';
+import getApp from './index.js';
 import type { FastifyInstance } from 'fastify';
 
 const app: FastifyInstance = await getApp();
 
-const port: number = process.env.PORT ? parseInt(process.env.PORT) : 3001;
+const port: number = process.env.PORT ? parseInt(process.env.PORT) : 3000;
 const host: string = process.env.HOST || '0.0.0.0';
 
 app.listen({ port, host }, (err: Error | null, address: string) => {


### PR DESCRIPTION
### Motivation
- Исправить падение production-сборки в ESM-режиме, когда `node dist/server.js` не мог резолвить внутренние модули после транспиляции. 
- Устранить ошибку в конфигурации Playwright, вызванную использованием CommonJS `require` в ESM-файле.
- Привести дефолтный порт сервера в соответствие с ожиданиями тестов/локального окружения.

### Description
- Удалён `require('dotenv').config()` из `playwright.config.ts` чтобы избежать `ReferenceError: require is not defined` в ESM.
- Во всех внутренних импортах серверного кода добавлены явные `.js` расширения (например `import ... from './router/index.js'`) чтобы скомпилированные `dist` файлы корректно резолвились в Node ESM.
- Изменён дефолтный порт в `src/server.ts` с `3001` на `3000` для соответствия `playwright` и локальным ожиданиям.

### Testing
- Запуск сборки `npm run build` прошёл успешно (миграции и `tsc` выполнены). ✅
- `npm start` был запущен и ответил на `GET /` с HTTP 200, подтверждая, что сервер стартует и роут `/` работает. ✅
- `npm test` завершился с ошибками, но причину составляет отсутствие установленных бинарников браузеров Playwright в окружении (требуется выполнить `npx playwright install`), а не изменения в коде. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d72f1968833382fce42d8bab3e67)