### PR TITLE
fix: run build step before starting production server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "npm run db:setup && tsx watch src/server.ts",
     "build": "npm run db:setup && tsc",
-    "start": "node dist/server.js",
+    "start": "npm run build && node dist/server.js",
     "db:setup": "npm run db:generate && npm run db:migrate",
     "db:migrate": "drizzle-kit migrate",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
### Motivation
- Ensure `npm start` builds the project first so it does not fail on a fresh checkout due to a missing `dist/server.js`.

### Description
- Updated the `start` script in `package.json` to `npm run build && node dist/server.js` so the build/db-setup runs before launching the production server.

### Testing
- Ran `npm run build` (succeeded: migrations generation/migration and `tsc` completed) and `npm start` (now performs the build, but the runtime failed with `EADDRINUSE` because port `3000` is already occupied in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dc0327f48333b17916c15371227a)