### PR TITLE
docs: clarify backend/frontend startup flow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Tasks can be discussed in [Telegram](https://t.me/hexletcommunity/12).
 * [Yarn 1 (Classic)](https://classic.yarnpkg.com/)
 * PostgreSQL for use in production environments or SQLite for use in local development environments
 
+## Quick start
+
+```bash
+git clone git@github.com:hexlet-rus/runit.git
+cd runit
+```
+
 ## Install dependencies for backend and run
 
 ```bash
@@ -39,6 +46,8 @@ cd frontend
 yarn
 yarn start
 ```
+
+If you see `cd: no such file or directory: frontend`, make sure you are in the project root (`.../runit`) before running the frontend commands.
 
 <http://localhost:3000>
 


### PR DESCRIPTION
### Motivation
- Clarify startup instructions so contributors run backend and frontend commands from the project root and avoid the common `cd: no such file or directory: frontend` error.

### Description
- Add a `Quick start` section with `git clone` and `cd runit` steps and include a troubleshooting note about running frontend commands from the repository root while keeping existing backend/frontend commands intact.

### Testing
- Documentation-only change; validated by running `git diff -- README.md`, inspecting the updated README with `nl`, and confirming the commit with `git show --stat`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dc227bc8833388a4d634fbe4976d)