### PR TITLE
Fix root path redirecting to /profile on local frontend

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -79,16 +79,7 @@ function AppRoutes() {
           path={routes.consentToProcessingPath()}
           element={<ConsentToProcesing />}
         />
-        <Route
-          element={
-            <ProtectedRoute
-              isAllowed={!isLoggedIn}
-              redirectTo={routes.myProfilePagePath()}
-            />
-          }
-        >
-          <Route index element={<Landing />} />
-        </Route>
+        <Route index element={<Landing />} />
         <Route element={<Layout />}>
           <Route path={routes.homePagePath()} element={<SnippetPage />} />
           <Route path={routes.snippetPagePath()} element={<SnippetPage />} />


### PR DESCRIPTION
### Motivation
- The root route (`/`) was wrapped in a guest-only `ProtectedRoute` with `isAllowed={!isLoggedIn}` and `redirectTo={routes.myProfilePagePath()}`, causing authenticated users opening `http://localhost:3000` to be redirected to `/profile` instead of seeing the landing page.

### Description
- Removed the guest-only `ProtectedRoute` wrapper and left the index route mapped directly to `Landing` in `frontend/src/AppRoutes.tsx`, so `Route index` now renders `Landing` without imposing `routes.myProfilePagePath()` redirect.

### Testing
- Ran `yarn --cwd frontend lint`, which executed but failed due to many pre-existing linting issues unrelated to this specific change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e5bcfb948333a12e0193ff2863a4)