### PR TITLE
Fix landing UI, dark mode, i18n removal and robust code run action

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -57,6 +57,10 @@ function AppRoutes() {
       'data-bs-theme',
       isDarkMode ? 'dark' : 'light',
     );
+    document.documentElement.setAttribute(
+      'data-mantine-color-scheme',
+      isDarkMode ? 'dark' : 'light',
+    );
   }, [isDarkMode]);
 
   if (!isAuthResolved) {

--- a/frontend/src/hooks/useRunButton.ts
+++ b/frontend/src/hooks/useRunButton.ts
@@ -17,9 +17,19 @@ const useRunButton = (): UseRunButtonReturn => {
   );
   const snippet = useSelector((state: RootState) => state.editor.snippetData);
   const code = useSelector((state: RootState) => state.editor.code);
+  const currentLanguage = useSelector(
+    (state: RootState) => state.languages.currentLanguage,
+  );
   const onClick = useCallback(
-    () => dispatch(runCode({ ...snippet, code } as FetchedTerminalDataType)),
-    [dispatch, code, snippet],
+    () =>
+      dispatch(
+        runCode({
+          ...snippet,
+          code,
+          language: snippet.language ?? currentLanguage,
+        } as FetchedTerminalDataType),
+      ),
+    [dispatch, code, snippet, currentLanguage],
   );
   const update = async (id: number, name: string) => {
     const response = await axios.put(routes.updateSnippetPath(id), {
@@ -41,6 +51,5 @@ const useRunButton = (): UseRunButtonReturn => {
 };
 
 export default useRunButton;
-
 
 

--- a/frontend/src/initI18next.ts
+++ b/frontend/src/initI18next.ts
@@ -4,7 +4,7 @@ import { initReactI18next } from 'react-i18next';
 import { AvailableLanguages } from './types/common';
 import resources from './locales';
 
-const defaultLanguage = localStorage.getItem('language') || 'ru';
+const defaultLanguage = 'ru';
 const baseI18NextConfig = {
   debug: import.meta.env.MODE === 'development',
   resources,
@@ -12,7 +12,6 @@ const baseI18NextConfig = {
 
 
 export const AVAILABLE_LANGUAGES: AvailableLanguages[] = [
-  AvailableLanguages.EN,
   AvailableLanguages.RU
 ];
 

--- a/frontend/src/locales/index.ts
+++ b/frontend/src/locales/index.ts
@@ -1,7 +1,5 @@
 import ru from './ru.json';
-import en from './en.json';
 
 export default {
   ru: { translation: ru },
-  en: { translation: en },
 };

--- a/frontend/src/pages/ProfileEditFormPage/Header.tsx
+++ b/frontend/src/pages/ProfileEditFormPage/Header.tsx
@@ -8,10 +8,7 @@ function Header() {
     keyPrefix: 'profileEdit',
   });
 
-  const { language, setLanguage } = useLanguage();
-  const handleChangeLanguage = () => {
-    setLanguage(language === 'ru' ? 'en' : 'ru');
-  };
+  const { setLanguage } = useLanguage();
 
   const { signOut } = useAuth();
 
@@ -32,7 +29,7 @@ function Header() {
         </Group>
         <Group align="center" justify="flex-end">
           <ActionIcon
-            onClick={() => handleChangeLanguage()}
+            onClick={() => setLanguage('ru')}
             size="lg"
             variant="default"
           >

--- a/frontend/src/pages/landing/MainBanner.tsx
+++ b/frontend/src/pages/landing/MainBanner.tsx
@@ -13,9 +13,11 @@ import {
   ThemeIcon,
   Title,
 } from '@mantine/core';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import PencilIcon from './assets/IconMainBanner/Pencil.svg?react';
 import PlayIcon from './assets/IconMainBanner/Play.svg?react';
+import routes from '../../routes';
 
 interface HeroBannerContent {
   id: number;
@@ -77,6 +79,7 @@ const featureItems = (data: HeroBannerContent[]) =>
   ));
 
 function HeroBanner({ data = mockData }: HeroBannerProps) {
+  const navigate = useNavigate();
   const codeExample = `function greet(name) {
   console.log('Hello, ' + name);
 }
@@ -106,7 +109,12 @@ greet('RunIT');`;
             <Text c="dimmed" maw={560} size="lg">
               {data.subtitle}
             </Text>
-            <Button mt="xl" radius="xl" size="md">
+            <Button
+              mt="xl"
+              onClick={() => navigate(routes.homePagePath())}
+              radius="xl"
+              size="md"
+            >
               {data.CTA}
             </Button>
             <SimpleGrid cols={{ base: 1, sm: 3 }} mt="xl" spacing="sm">
@@ -115,7 +123,7 @@ greet('RunIT');`;
           </Grid.Col>
 
           <Grid.Col span={{ base: 12, lg: 6 }}>
-            <Card bg="#1a1b1e" p={0} radius="md" withBorder>
+            <Card bg="dark.8" p={0} radius="md" withBorder>
               <Group gap="xs" justify="space-between" px="md" py="sm">
                 <Group gap="xs">
                   <ThemeIcon color="red" radius="xl" size={10} />
@@ -136,13 +144,21 @@ greet('RunIT');`;
                 </Badge>
               </Group>
               <Divider color="gray.7" />
-              <Code block c="white" color="#1a1b1e" h={132} px="md" py="sm">
+              <Code
+                block
+                c="white"
+                color="#1a1b1e"
+                h={{ base: 170, sm: 132 }}
+                px="md"
+                py="sm"
+              >
                 {codeExample}
               </Code>
               <Group gap="xs" px="md" py="md">
                 <Button
                   color="blue"
                   leftSection={<PlayIcon style={{ height: 15 }} />}
+                  onClick={() => navigate(routes.homePagePath())}
                 >
                   Запустить
                 </Button>

--- a/frontend/src/pages/landing/home-page.tsx
+++ b/frontend/src/pages/landing/home-page.tsx
@@ -1,4 +1,5 @@
 import { AppShell, Box } from '@mantine/core';
+import { useTernaryDarkMode } from 'usehooks-ts';
 import TechnologiesSection, { mockDataTechnology } from './TechnologiesSection';
 import { SectionContainer } from './layout';
 import FeaturesSection from './FeaturesSection';
@@ -9,8 +10,19 @@ import CommunitySection, { communityMockData } from './CommunitySection';
 import Footer from './Footer-1';
 
 function HomePage() {
+  const { isDarkMode } = useTernaryDarkMode();
+
   return (
-    <AppShell header={{ height: 80 }}>
+    <AppShell
+      header={{ height: 80 }}
+      styles={{
+        main: {
+          backgroundColor: isDarkMode
+            ? 'var(--mantine-color-dark-8)'
+            : 'var(--mantine-color-white)',
+        },
+      }}
+    >
       <AppShell.Header withBorder>
         <SectionContainer>
           <Header />
@@ -25,7 +37,7 @@ function HomePage() {
         </Box>
 
         <Box
-          bg="gray.0"
+          bg={isDarkMode ? 'dark.7' : 'gray.0'}
           component="section"
           id="opportunities"
           py={{ base: 36, md: 64 }}
@@ -42,7 +54,7 @@ function HomePage() {
         </Box>
 
         <Box
-          bg="gray.0"
+          bg={isDarkMode ? 'dark.7' : 'gray.0'}
           component="section"
           id="community"
           py={{ base: 36, md: 64 }}

--- a/frontend/src/slices/terminalSlice.ts
+++ b/frontend/src/slices/terminalSlice.ts
@@ -12,18 +12,58 @@ import { actions as editorActions } from './editorSlice';
 export const runCode = createAsyncThunk(
   'terminal/runCode',
   async (snippet: FetchedTerminalDataType) => {
-    // TODO: захардкоден урл, плюс тут явно не нужен createAsyncThunk. (Урл исправлен)
-    const { data, status } = await axios.get(routes.runCode(), {
-      params: {
-        snippet: {
-          code: snippet.code,
-          language: snippet.language,
-        },
-      },
-    });
+    const runJsLocally = () => {
+      const terminal: string[] = [];
 
-    if (status === 200) return data;
-    return 'Connection issues';
+      const mockConsole = {
+        log: (...args: unknown[]) => terminal.push(args.map(String).join(' ')),
+      };
+
+      try {
+        // eslint-disable-next-line no-new-func
+        const runner = new Function('console', snippet.code);
+        runner(mockConsole);
+
+        if (terminal.length === 0) {
+          terminal.push('Код выполнен без вывода');
+        }
+
+        return { terminal, alertLogs: [] };
+      } catch (error) {
+        return {
+          terminal: [],
+          alertLogs: [error instanceof Error ? error.message : 'Ошибка выполнения'],
+        };
+      }
+    };
+
+    try {
+      const { data, status } = await axios.get(routes.runCode(), {
+        params: {
+          snippet: {
+            code: snippet.code,
+            language: snippet.language,
+          },
+        },
+      });
+
+      if (status === 200) {
+        return data;
+      }
+    } catch (_error) {
+      if (snippet.language === 'javascript') {
+        return runJsLocally();
+      }
+
+      return {
+        terminal: [],
+        alertLogs: [
+          'Запуск для этого языка временно недоступен. Попробуйте JavaScript.',
+        ],
+      };
+    }
+
+    return { terminal: [], alertLogs: ['Connection issues'] };
   },
   {
     condition: (code, { getState }) => {


### PR DESCRIPTION
### Motivation
- Improve landing page layout and mobile/desktop consistency and ensure dark theme is applied correctly across components. 
- Remove the unused English UI to simplify language handling. 
- Fix the non-working "Run" action so snippets can be executed reliably. 

### Description
- Remove active English locale and lock UI language to Russian by updating `frontend/src/locales/index.ts` and `frontend/src/initI18next.ts` so only `ru` is loaded and `defaultLanguage` is `ru`. 
- Ensure Mantine reacts to theme changes by syncing `data-mantine-color-scheme` with the app dark mode in `frontend/src/AppRoutes.tsx`. 
- Make landing sections theme-aware and stabilize hero demo sizing and CTA behavior by updates in `frontend/src/pages/landing/home-page.tsx` and `frontend/src/pages/landing/MainBanner.tsx`, and wire hero CTA/demo "Запустить" to open the editor route. 
- Fix run payload and fallback execution: always include a language in the run request by changing `frontend/src/hooks/useRunButton.ts`, and add a resilient fallback in `frontend/src/slices/terminalSlice.ts` that executes JavaScript snippets locally when the backend runner is unavailable and returns a clear message for other languages. 
- Adjust profile edit header language control to not toggle to English (set to `ru`) in `frontend/src/pages/ProfileEditFormPage/Header.tsx`. 

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully. 
- Captured landing screenshots with Playwright for mobile and desktop to validate visual changes (artifacts produced). 
- Ran `npm --prefix frontend run lint`, but the lint process was long-running in this environment and did not complete within allotted time; no blocking lint errors were fixed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1edca0f308333852df7b41d821333)