### PR TITLE
Add community feature cards section on landing page

### DIFF
--- a/frontend/src/pages/landing/CommunityFeaturesCards.module.css
+++ b/frontend/src/pages/landing/CommunityFeaturesCards.module.css
@@ -1,0 +1,17 @@
+.title {
+  font-weight: 700;
+}
+
+.description {
+  max-width: 680px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.card {
+  height: 100%;
+}
+
+.cardTitle {
+  line-height: 1.2;
+}

--- a/frontend/src/pages/landing/CommunityFeaturesCards.tsx
+++ b/frontend/src/pages/landing/CommunityFeaturesCards.tsx
@@ -1,0 +1,88 @@
+import { Cookie, Person, Speedometer2 } from 'react-bootstrap-icons';
+import {
+  Badge,
+  Card,
+  Container,
+  Group,
+  SimpleGrid,
+  Text,
+  ThemeIcon,
+  Title,
+  useMantineTheme,
+} from '@mantine/core';
+import classes from './CommunityFeaturesCards.module.css';
+
+const mockdata = [
+  {
+    title: 'Быстрый рост',
+    description:
+      'Участвуйте в обсуждениях, разборах кода и активностях сообщества, чтобы быстрее прокачивать навыки.',
+    icon: Speedometer2,
+  },
+  {
+    title: 'Поддержка участников',
+    description:
+      'Получайте помощь от участников и менторов по задачам, карьерным вопросам и техническим решениям.',
+    icon: Person,
+  },
+  {
+    title: 'Без посредников',
+    description:
+      'Общайтесь напрямую с разработчиками и участниками сообщества в открытых каналах и клубе.',
+    icon: Cookie,
+  },
+];
+
+function CommunityFeaturesCards() {
+  const theme = useMantineTheme();
+
+  const features = mockdata.map((feature) => (
+    <Card
+      key={feature.title}
+      className={classes.card}
+      padding="xl"
+      radius="md"
+      shadow="md"
+    >
+      <ThemeIcon
+        color={theme.primaryColor}
+        radius="xl"
+        size={56}
+        variant="light"
+      >
+        <feature.icon size={28} />
+      </ThemeIcon>
+      <Text className={classes.cardTitle} fw={500} fz="lg" mt="md">
+        {feature.title}
+      </Text>
+      <Text c="dimmed" fz="sm" mt="sm">
+        {feature.description}
+      </Text>
+    </Card>
+  ));
+
+  return (
+    <Container p={0} size="lg">
+      <Group justify="center">
+        <Badge size="lg" variant="filled">
+          Сильное комьюнити
+        </Badge>
+      </Group>
+
+      <Title className={classes.title} mt="sm" order={2} ta="center">
+        Растите вместе с RunIT сообществом
+      </Title>
+
+      <Text c="dimmed" className={classes.description} mt="md" ta="center">
+        Каналы, клуб и живые обсуждения помогают быстрее находить ответы,
+        обмениваться опытом и двигаться в профессии.
+      </Text>
+
+      <SimpleGrid cols={{ base: 1, md: 3 }} mt={40} spacing="xl">
+        {features}
+      </SimpleGrid>
+    </Container>
+  );
+}
+
+export default CommunityFeaturesCards;

--- a/frontend/src/pages/landing/CommunitySection.tsx
+++ b/frontend/src/pages/landing/CommunitySection.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
 } from '@mantine/core';
 import type { CommunityType } from 'src/types/components';
+import CommunityFeaturesCards from './CommunityFeaturesCards';
 
 export const communityMockData = [
   {
@@ -89,6 +90,10 @@ function CommunitySection({ communities }: CommunitySectionProps) {
           </Card>
         ))}
       </SimpleGrid>
+
+      <Box mt={56}>
+        <CommunityFeaturesCards />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
### Motivation
- Add a visual block to the landing page community section to showcase community advantages and increase engagement. 

### Description
- Add new component `CommunityFeaturesCards` at `frontend/src/pages/landing/CommunityFeaturesCards.tsx` that renders a badge, title, description and three feature cards. 
- Add styles for the component in `frontend/src/pages/landing/CommunityFeaturesCards.module.css` for title, description width, card sizing and card title. 
- Integrate the new `CommunityFeaturesCards` into the existing `CommunitySection` at `frontend/src/pages/landing/CommunitySection.tsx` and render it below the existing channel/club cards. 

### Testing
- Ran `yarn --cwd frontend prettier --write src/pages/landing/CommunitySection.tsx src/pages/landing/CommunityFeaturesCards.tsx src/pages/landing/CommunityFeaturesCards.module.css` which completed successfully. 
- Ran `yarn --cwd frontend build` which completed successfully. 
- Started the dev server with `yarn --cwd frontend start` and captured a screenshot of the updated landing page section via an automated Playwright script to validate rendering. 
- Ran `yarn --cwd frontend lint` which failed due to many pre-existing lint issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f485a3a08333b05897669ae1c95e)