### PR TITLE
Improve backend startup reliability and reduce noisy logs

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -11,8 +11,9 @@ const __dirname = path.dirname(__filename);
 const dbPath = process.env.DB_PATH || 'database.sqlite';
 const sqlite = new Database(dbPath);
 
-// Включение WAL режима для лучшей производительности
-// sqlite.pragma('journal_mode = WAL');
+if (process.env.SQLITE_WAL_MODE !== 'off') {
+  sqlite.pragma('journal_mode = WAL');
+}
 
 export const db = drizzle(sqlite, { schema });
 
@@ -20,16 +21,21 @@ export const runMigrations = async () => {
   try {
     const migrationsPath = path.join(__dirname, '../../drizzle');
     await migrate(db, { migrationsFolder: migrationsPath });
-    console.log('Migrations completed successfully');
   } catch (error) {
     console.error('Migration failed:', error);
     throw error;
   }
 };
 
-process.on('exit', () => sqlite.close());
+let isClosed = false;
+const closeSqlite = () => {
+  if (!isClosed) {
+    sqlite.close();
+    isClosed = true;
+  }
+};
+
+process.on('exit', closeSqlite);
 process.on('SIGHUP', () => process.exit(128 + 1));
 process.on('SIGINT', () => process.exit(128 + 2));
 process.on('SIGTERM', () => process.exit(128 + 15));
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,76 +1,55 @@
 import { fastify } from 'fastify';
-import { fastifyTRPCPlugin, FastifyTRPCPluginOptions, } from '@trpc/server/adapters/fastify';
+import { fastifyTRPCPlugin, FastifyTRPCPluginOptions } from '@trpc/server/adapters/fastify';
 
 import { runMigrations } from './db/connection.js';
 import { appRouter, type AppRouter } from './router/index.js';
-// import { createContext } from './context';
 
 const getApp = async () => {
-   try {
+  try {
     await runMigrations();
   } catch (error) {
     console.error('Migration failed:', error);
     throw error;
   }
- 
-// to do: подключить полноценное логирование (pino-pretty)
-// убрать consol.log с прода
 
   const server = fastify({
-  logger: {
-    level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-  },
-  routerOptions: {
-    maxParamLength: 1000,
-    caseSensitive: false,
-    ignoreTrailingSlash: true
-  },
-});
-
-  console.log('🔍 appRouter type:', typeof appRouter);
-  // console.log('🔍 createContext type:', typeof createContext);
-  console.log('🔍 appRouter procedures:', Object.keys(appRouter._def?.procedures || {}));
-
-  server.get('/', async (request, reply) => {
-    reply.type('text/html').send(`
-      <!DOCTYPE html>
-      <html lang="en">
-      <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Welcome</title>
-      </head>
-      <body>
-        <h2>WELCOME</h2>
-        <p>Available procedures: ${Object.keys(appRouter._def?.procedures || {}).join(', ')}</p>
-      </body>
-      </html>
-    `);
+    logger: {
+      level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+    },
+    routerOptions: {
+      maxParamLength: 1000,
+      caseSensitive: false,
+      ignoreTrailingSlash: true,
+    },
   });
 
-  server.get('/hello', async (request, reply) => {
+  server.get('/', async (_request, reply) => {
+    reply.type('application/json').send({
+      status: 'ok',
+      service: 'runit-api',
+      procedures: Object.keys(appRouter._def?.procedures || {}),
+    });
+  });
+
+  server.get('/hello', async (_request, reply) => {
     reply.type('text/plain').send('Hello world');
   });
 
-    try {
-    console.log('📡 Registering tRPC plugin...');
-    
+  try {
     await server.register(fastifyTRPCPlugin, {
       prefix: '/trpc',
       trpcOptions: {
         router: appRouter,
-        // createContext,
         onError({ path, error }) {
-          console.error(`❌ tRPC Error on path '${path}':`, error.message);
+          server.log.error({ path, error }, 'tRPC request failed');
         },
       } satisfies FastifyTRPCPluginOptions<AppRouter>['trpcOptions'],
     });
-    
-    console.log('✅ tRPC plugin registered successfully');
   } catch (error) {
-    console.error('❌ Failed to register tRPC plugin:', error);
+    console.error('Failed to register tRPC plugin:', error);
     throw error;
   }
+
   return server;
 };
 

--- a/src/router/snippetRouter.ts
+++ b/src/router/snippetRouter.ts
@@ -41,7 +41,6 @@ export const snippetRouter = router({
 
   getAllSnippets: publicProcedure
     .query(async () => {
-      console.log('getAllSnippets called');
       return await getAllSnippets();
     }),
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,8 @@ import type { FastifyInstance } from 'fastify';
 
 const app: FastifyInstance = await getApp();
 
-const port: number = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10);
+const port: number = Number.isNaN(parsedPort) ? 3000 : parsedPort;
 const host: string = process.env.HOST || '0.0.0.0';
 
 app.listen({ port, host }, (err: Error | null, address: string) => {


### PR DESCRIPTION
### Motivation
- Prevent server startup failures caused by invalid `PORT` values and provide a safe default port.
- Reduce noisy debug output and make the root endpoint machine-readable for health checks.
- Ensure SQLite operates in WAL mode by default for performance while allowing opt-out, and make DB shutdown safe.
- Use structured logging for tRPC errors instead of ad-hoc `console.log` messages.

### Description
- Hardened port parsing in `src/server.ts` using `Number.parseInt(..., 10)` with a fallback to `3000` when the value is invalid.
- Reworked `src/index.ts` to return a JSON health response at `/`, removed noisy debug `console.log`s, and switched tRPC error reporting to Fastify structured logger via `server.log.error`.
- Enabled WAL mode for SQLite by default in `src/db/connection.ts` (opt-out with `SQLITE_WAL_MODE=off`) and made the SQLite close handler idempotent to avoid double-close issues.
- Removed an extra `console.log` from `getAllSnippets` in `src/router/snippetRouter.ts` to reduce log noise.

### Testing
- Ran `npm run build` which executed `db:generate`, `db:migrate`, and `tsc`, and completed successfully.
- Ran `npm test` but Playwright tests failed in this environment due to missing browser binaries (`npx playwright install` required), which is unrelated to these backend changes.
- Verified migrations step during build (`drizzle-kit generate` / `drizzle-kit migrate`) completed successfully during the build process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f9e0e9d48333b36a1f516cc66e95)