### PR TITLE
Add community CTA buttons and replace CommunitySection with CommunityFeaturesCards on home page

### DIFF
--- a/frontend/src/pages/landing/CommunityFeaturesCards.tsx
+++ b/frontend/src/pages/landing/CommunityFeaturesCards.tsx
@@ -1,6 +1,7 @@
 import { Cookie, Person, Speedometer2 } from 'react-bootstrap-icons';
 import {
   Badge,
+  Button,
   Card,
   Container,
   Group,
@@ -77,6 +78,29 @@ function CommunityFeaturesCards() {
         Каналы, клуб и живые обсуждения помогают быстрее находить ответы,
         обмениваться опытом и двигаться в профессии.
       </Text>
+
+      <Group justify="center" mt="xl">
+        <Button
+          component="a"
+          href="https://t.me/hexletcommunity"
+          radius="xl"
+          rel="noreferrer"
+          target="_blank"
+          variant="filled"
+        >
+          Вступить в сообщество
+        </Button>
+        <Button
+          component="a"
+          href="https://t.me/HexletClubBot"
+          radius="xl"
+          rel="noreferrer"
+          target="_blank"
+          variant="default"
+        >
+          Вступить в клуб
+        </Button>
+      </Group>
 
       <SimpleGrid cols={{ base: 1, md: 3 }} mt={40} spacing="xl">
         {features}

--- a/frontend/src/pages/landing/home-page.tsx
+++ b/frontend/src/pages/landing/home-page.tsx
@@ -6,7 +6,7 @@ import FeaturesSection from './FeaturesSection';
 import HeroBanner, { mockData } from './MainBanner';
 import { Header } from './Header';
 import CallToAction from './CallToAction';
-import CommunitySection, { communityMockData } from './CommunitySection';
+import CommunityFeaturesCards from './CommunityFeaturesCards';
 import Footer from './Footer-1';
 
 function HomePage() {
@@ -53,14 +53,9 @@ function HomePage() {
           </SectionContainer>
         </Box>
 
-        <Box
-          bg={isDarkMode ? 'dark.7' : 'gray.0'}
-          component="section"
-          id="community"
-          py={{ base: 36, md: 64 }}
-        >
+        <Box bg={isDarkMode ? 'dark.7' : 'gray.0'} component="section" py={{ base: 36, md: 64 }}>
           <SectionContainer>
-            <CommunitySection communities={communityMockData} />
+            <CommunityFeaturesCards />
           </SectionContainer>
         </Box>
 
@@ -71,11 +66,11 @@ function HomePage() {
         </Box>
       </AppShell.Main>
 
-      <AppShell.Footer pos="relative" withBorder>
+      <Box component="footer">
         <SectionContainer>
           <Footer />
         </SectionContainer>
-      </AppShell.Footer>
+      </Box>
     </AppShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Surface clear calls-to-action to join the community and club directly from the landing page to increase engagement.
- Replace the previous community section component with a focused cards component to unify the community block UI.
- Simplify the footer wrapper to use a standard `Box` element instead of `AppShell.Footer` for consistent layout control.

### Description
- Added two CTA `Button`s to `CommunityFeaturesCards.tsx` linking to the community (`https://t.me/hexletcommunity`) and club (`https://t.me/HexletClubBot`) Telegram destinations, and imported `Button` from `@mantine/core`.
- Kept the features card list and descriptive text while inserting a centered `Group` that contains the new CTA buttons with appropriate props (`component="a"`, `target="_blank"`, `rel="noreferrer"`).
- Updated `home-page.tsx` to import and render `CommunityFeaturesCards` in place of the previous `CommunitySection` and removed the section `id="community"` attribute.
- Replaced `AppShell.Footer` with a `Box` component wrapping the `Footer` to simplify footer positioning and styling.

### Testing
- Ran the project build with `yarn build`, which completed successfully.
- Executed the test suite with `yarn test`, and all tests passed.
- Ran `yarn lint` to verify linting rules, and no new linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f84a6658833388aa0fb752a7ef2e)